### PR TITLE
chore: update doc page from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "apigeeconnect",
     "name_pretty": "Apigee Connect API",
     "product_documentation": "https://cloud.google.com/apigee/docs/hybrid/v1.4/apigee-connect",
-    "client_documentation": "https://googleapis.dev/python/apigeeconnect/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/apigeeconnect/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages.