### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "apigeeconnect",
     "name_pretty": "Apigee Connect API",
     "product_documentation": "https://cloud.google.com/apigee/docs/hybrid/v1.4/apigee-connect",
-    "client_documentation": "https://googleapis.dev/python/apigeeconnect/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/apigeeconnect/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ and an authorized DNS certificate.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-apigee-connect.svg
    :target: https://pypi.org/project/google-cloud-apigee-connect/
 .. _Apigee Connect: https://cloud.google.com/apigee/docs/hybrid/v1.4/apigee-connect
-.. _Client Library Documentation: https://googleapis.dev/python/apigeeconnect/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/apigeeconnect/latest
 .. _Product Documentation:  https://cloud.google.com/apigee/docs/hybrid/v1.4/apigee-connect
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.