### PR TITLE
chore: auto approve template changes

### DIFF
--- a/.github/auto-approve.yml
+++ b/.github/auto-approve.yml
@@ -1,0 +1,3 @@
+# https://github.com/googleapis/repo-automation-bots/tree/main/packages/auto-approve
+processes:
+  - "OwlBotTemplateChanges"


### PR DESCRIPTION
Enable [auto-approve](https://github.com/googleapis/repo-automation-bots/tree/main/packages/auto-approve) for owlbot template changes.